### PR TITLE
feat: load configuration from env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+HOST=localhost
+PORT=5000
+DATABASE_PATH=backend/database/cargo_manager.db

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+HOST=localhost
+PORT=5000
+DATABASE_PATH=backend/database/cargo_manager.db

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,17 +1,23 @@
 import sqlite3
 import os
 from datetime import datetime
+from dotenv import load_dotenv
+
+# Загружаем переменные окружения
+load_dotenv()
 
 def get_db():
     """
     Создает и возвращает подключение к базе данных.
     База данных ищется в папке database проекта.
     """
-    # Получаем путь к текущей папке (где находится этот файл)
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    
-    # Собираем путь к файлу базы данных
-    db_path = os.path.join(current_dir, 'cargo_manager.db')
+    # Путь к файлу базы данных из переменной окружения
+    db_path = os.getenv('DATABASE_PATH')
+
+    # Если переменная не задана, используем путь по умолчанию рядом с этим файлом
+    if not db_path:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        db_path = os.path.join(current_dir, 'cargo_manager.db')
     
     # Проверяем, существует ли файл базы данных
     if not os.path.exists(db_path):

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from dotenv import load_dotenv
 
 # Добавляем путь к проекту в sys.path для корректной работы импортов
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -8,6 +9,9 @@ if project_root not in sys.path:
 
 from flask import Flask, jsonify
 from flask_cors import CORS
+
+# Загружаем переменные окружения
+load_dotenv()
 
 # Импортируем компоненты приложения
 try:
@@ -65,14 +69,18 @@ def create_app():
 if __name__ == '__main__':
     # Создаем приложение
     app = create_app()
-    
+
+    # Читаем параметры запуска из переменных окружения
+    host = os.getenv('HOST', 'localhost')
+    port = int(os.getenv('PORT', '5000'))
+
     # Запускаем сервер
     print("Запуск Cargo Manager Лисёнок API сервера...")
-    print("Сервер доступен по адресу: http://localhost:5000")
-    print("Документация API: http://localhost:5000/api/health")
-    
+    print(f"Сервер доступен по адресу: http://{host}:{port}")
+    print(f"Документация API: http://{host}:{port}/api/health")
+
     app.run(
-        host='localhost',
-        port=5000,
+        host=host,
+        port=port,
         debug=True
     )


### PR DESCRIPTION
## Summary
- load python backend settings from .env
- provide example env file

## Testing
- `pytest`
- `python -m py_compile backend/main.py backend/database/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b5f1ac488327b41e8de8e56d8618