### PR TITLE
Add JWT auth and CORS restrictions

### DIFF
--- a/backend/api/currency.py
+++ b/backend/api/currency.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
 
 from backend.services.currency_service import get_rates, update_rates_now, convert_amounts
 
@@ -7,18 +8,21 @@ currency_bp = Blueprint('currency', __name__)
 
 
 @currency_bp.route('/api/currency/rates', methods=['GET'])
+@jwt_required()
 def rates():
     rates, last_update = get_rates()
     return jsonify({'rates': rates, 'last_update': last_update}), 200
 
 
 @currency_bp.route('/api/currency/update-now', methods=['POST'])
+@jwt_required()
 def update_now():
     rates, last_update = update_rates_now()
     return jsonify({'status': 'success', 'rates': rates, 'last_update': last_update}), 200
 
 
 @currency_bp.route('/api/currency/conversions', methods=['GET'])
+@jwt_required()
 def conversions():
     amount = request.args.get('amount', type=float)
     from_code = request.args.get('from', default='CNY', type=str)

--- a/backend/api/orders.py
+++ b/backend/api/orders.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
 import sys
 import os
 
@@ -14,6 +15,7 @@ from backend.services import order_service
 orders_bp = Blueprint('orders', __name__)
 
 @orders_bp.route('/api/orders', methods=['GET'])
+@jwt_required()
 def get_orders():
     """
     Получает список всех заявок.
@@ -29,6 +31,7 @@ def get_orders():
         return jsonify({'error': f'Ошибка при получении заявок: {str(e)}'}), 500
 
 @orders_bp.route('/api/orders/<order_id>', methods=['GET'])
+@jwt_required()
 def get_order(order_id):
     """
     Получает заявку по её идентификатору.
@@ -49,6 +52,7 @@ def get_order(order_id):
         return jsonify({'error': f'Ошибка при получении заявки: {str(e)}'}), 500
 
 @orders_bp.route('/api/orders', methods=['POST'])
+@jwt_required()
 def create_order():
     """
     Создает новую заявку.
@@ -87,6 +91,7 @@ def create_order():
         return jsonify({'error': f'Ошибка при создании заявки: {str(e)}'}), 500
 
 @orders_bp.route('/api/orders/<order_id>', methods=['PUT'])
+@jwt_required()
 def update_order(order_id):
     """
     Обновляет существующую заявку.
@@ -125,6 +130,7 @@ def update_order(order_id):
         return jsonify({'error': f'Ошибка при обновлении заявки: {str(e)}'}), 500
 
 @orders_bp.route('/api/orders/<order_id>', methods=['DELETE'])
+@jwt_required()
 def delete_order(order_id):
     """
     Удаляет заявку по её идентификатору.


### PR DESCRIPTION
## Summary
- integrate flask-jwt-extended with JWTManager and login route
- restrict CORS to allowed origins
- secure orders and currency APIs with jwt_required decorators

## Testing
- `python -m py_compile backend/main.py backend/api/orders.py backend/api/currency.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b5f262a0832780afe43636feb05b